### PR TITLE
fix: align MCP hosted OAuth connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We present: A Model Context Protocol (MCP) server for the [Sokosumi AI agent pl
 ## Features
 
 - **Two Setup Options** – Choose the best method for your needs:
-  - **Method 1: Instant MCP Connection** – Generate a link and connect to Claude in seconds
+  - **Method 1: Instant MCP Connection** – Connect to the hosted MCP server with OAuth
   - **Method 2: Local Development** – Run your own server for customization and testing
 - **Always Up-to-Date** – Uses the latest technology standards for reliable performance.
 
@@ -14,26 +14,25 @@ We present: A Model Context Protocol (MCP) server for the [Sokosumi AI agent pl
 ## Method 1: Quick Setup (Recommended)
 ### Connect Claude to Sokosumi (fastest MCP integration)
 
-The fastest way to get started is by generating an MCP link directly from the Sokosumi app and connecting it to Claude:
+The fastest way to get started is by adding the hosted Sokosumi MCP server to Claude. The server uses OAuth, so you sign in with your Sokosumi account during the connection flow instead of copying an API key.
 
 <MCPDemoVideo src="/assets/mcp-setup-demo.mp4" />
 
-1. **Generate MCP Link**
-   - Go to your [Sokosumi app](https://app.sokosumi.com)
-   - Click on your profile menu
-   - Select "MCP" from the menu options   
-   - Click "Generate Your Sokosumi MCP URL" button
-   - Copy the generated connection URL   
+1. **Copy the MCP Server URL**
+   - Go to [app.sokosumi.com/connections](https://app.sokosumi.com/connections)
+   - Open the **MCP** tab
+   - Copy the hosted server URL: `https://mcp.sokosumi.com/mcp`
 
 2. **Connect to Claude Desktop**
    - Open Claude Desktop
    - Go to **Settings** → **Connectors** → **Custom Connector**
-   - Paste your copied connection URL
+   - Paste the MCP server URL
    - Click "Connect"
+   - Complete the Sokosumi OAuth sign-in when Claude opens the browser
    
 3. **You're Ready!**
    - The Sokosumi tools are now available in Claude Desktop
-   - No manual configuration files or local server setup required
+   - No API key copy, manual configuration file, or local server setup required
 
 ### Example Questions to Ask Claude
 
@@ -301,10 +300,10 @@ Do not commit API keys or OAuth tokens. Use the hosted OAuth flow for normal usa
 
 If you're having trouble connecting:
 
-1. **Double-check your MCP link** - Make sure you copied the complete link including the API key parameter
-2. **Verify your API key** - Check that your API key is active in your [Sokosumi Account Settings](https://app.sokosumi.com/account)
+1. **Use the hosted MCP URL** - `https://mcp.sokosumi.com/mcp`
+2. **Complete OAuth** - Claude should open a browser and ask you to sign in to Sokosumi
 3. **Try reconnecting** - In Claude Desktop, disconnect and reconnect the MCP server
-4. **Check network** - Ensure you're using the correct network (mainnet/preprod) for your account
+4. **Local development only** - If you run the server yourself, verify your `SOKOSUMI_API_KEY` and `SOKOSUMI_NETWORK`
 
 
 ### Advanced Troubleshooting

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ pip install -r requirements.txt
 
 #### Step 6: Get Your API Key
 
-1. Visit [Account Settings](https://app.sokosumi.com/account)
-2. Scroll down to the API Keys section
+1. Go to [Connections](https://app.sokosumi.com/connections)
+2. Open the API Keys tab
 3. Generate or copy your API key
 
 #### Step 7: Configure Environment Variables
@@ -194,7 +194,7 @@ For local development, add to your Claude Desktop MCP configuration:
 
 Replace `/absolute/path/to/Sokosumi-MCP/server.py` with your actual path and restart Claude Desktop.
 
-**Note:** This method is only for local development. For production use, we recommend Method 1 (MCP Link Generation) above.
+**Note:** This method is only for local development. For production use, we recommend Method 1 (hosted MCP connection) above.
 
 ## Method 3: Claude Code Plugin
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ We present: A Model Context Protocol (MCP) server for the [Sokosumi AI agent pl
 
 
 ## Method 1: Quick Setup (Recommended)
-### Connect Claude to Sokosumi (fastest MCP integration)
+### Connect an MCP client to Sokosumi
 
-The fastest way to get started is by adding the hosted Sokosumi MCP server to Claude. The server uses OAuth, so you sign in with your Sokosumi account during the connection flow instead of copying an API key.
+The fastest way to get started is by adding the hosted Sokosumi MCP server to an MCP-capable client such as Claude Desktop, Claude Code, or Codex. The server uses OAuth, so you sign in with your Sokosumi account during the connection flow instead of copying an API key.
 
 <MCPDemoVideo src="/assets/mcp-setup-demo.mp4" />
 
@@ -23,20 +23,20 @@ The fastest way to get started is by adding the hosted Sokosumi MCP server to Cl
    - Open the **MCP** tab
    - Copy the hosted server URL: `https://mcp.sokosumi.com/mcp`
 
-2. **Connect to Claude Desktop**
-   - Open Claude Desktop
-   - Go to **Settings** → **Connectors** → **Custom Connector**
+2. **Connect to an MCP client**
+   - Open your MCP client, for example Claude Desktop
+   - In Claude Desktop, go to **Settings** → **Connectors** → **Custom Connector**
    - Paste the MCP server URL
    - Click "Connect"
-   - Complete the Sokosumi OAuth sign-in when Claude opens the browser
+   - Complete the Sokosumi OAuth sign-in when your client opens the browser
    
 3. **You're Ready!**
-   - The Sokosumi tools are now available in Claude Desktop
+   - The Sokosumi tools are now available in your MCP client
    - No API key copy, manual configuration file, or local server setup required
 
-### Example Questions to Ask Claude
+### Example Questions
 
-Once connected, try asking Claude:
+Once connected, try asking your MCP client:
 
 - "Show me all available AI agents on Sokosumi"
 - "What agents can help with image generation?"
@@ -46,7 +46,7 @@ Once connected, try asking Claude:
 - "What's my current credit balance?"
 
 <Callout type="tip">
-**Important Note about Jobs:** After submitting a job through Claude, you need to wait a few minutes for the process to complete. Once finished, simply ask Claude again for the result.
+**Important Note about Jobs:** Jobs usually take a few minutes to complete. Ask your MCP client to check the status, or use `/sokosumi:watch <job-or-task-id>` in Claude Code to get notified automatically.
 </Callout>
 
 
@@ -219,7 +219,7 @@ Claude Code plugin skills are namespaced by plugin name. Use:
 /sokosumi:market Build a market analysis plan for this product.
 ```
 
-Hannah and Elena automatically start a background monitor for every task they create, so a long-running task reports back on its own when it finishes or needs you — no manual status checks. If `SOKOSUMI_API_KEY` is set in your shell, the monitor polls with a standalone background script at zero model cost; otherwise it polls through the MCP server. You can also run `/sokosumi:watch <task-or-job-id>` yourself to monitor any task or job.
+Hannah, Elena, research, market, and direct agent workflows start a background monitor for long-running tasks or jobs they create, so work reports back on its own when it finishes or needs you. If `SOKOSUMI_API_KEY` is set in your shell, the monitor polls with a standalone background script at zero model cost; otherwise it polls through the MCP server. You can also run `/sokosumi:watch <task-or-job-id>` yourself to monitor any task or job.
 
 To create optional bare project aliases such as `/hannah`, `/elena`, `/research`, and `/market`, run:
 
@@ -301,8 +301,8 @@ Do not commit API keys or OAuth tokens. Use the hosted OAuth flow for normal usa
 If you're having trouble connecting:
 
 1. **Use the hosted MCP URL** - `https://mcp.sokosumi.com/mcp`
-2. **Complete OAuth** - Claude should open a browser and ask you to sign in to Sokosumi
-3. **Try reconnecting** - In Claude Desktop, disconnect and reconnect the MCP server
+2. **Complete OAuth** - Your MCP client should open a browser and ask you to sign in to Sokosumi
+3. **Try reconnecting** - Disconnect and reconnect the MCP server in your client
 4. **Local development only** - If you run the server yourself, verify your `SOKOSUMI_API_KEY` and `SOKOSUMI_NETWORK`
 
 

--- a/server.py
+++ b/server.py
@@ -111,6 +111,10 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             bearer_token = self._extract_bearer_token(request)
             if bearer_token:
                 if not self._is_mcp_access_token(bearer_token):
+                    if not await self._validate_sokosumi_bearer_token(bearer_token, network):
+                        logger.warning("Invalid direct Bearer token")
+                        return self._unauthorized_response("Invalid bearer token")
+
                     api_token = current_api_key.set(bearer_token)
                     api_keys["current"] = bearer_token
                     logger.info(
@@ -209,6 +213,35 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             or (isinstance(audience, list) and MCP_SERVER_URL in audience)
         )
         return payload.get("iss") == MCP_SERVER_URL and has_expected_audience
+
+    async def _validate_sokosumi_bearer_token(self, token: str, network: str) -> bool:
+        """Validate a direct Sokosumi bearer token before allowing MCP access."""
+        base_url = get_base_url(network)
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                for path in ("/v1/users/me", "/v1/coworkers/me"):
+                    response = await client.get(
+                        f"{base_url}{path}",
+                        headers=headers,
+                        timeout=10.0,
+                    )
+                    if 200 <= response.status_code < 300:
+                        return True
+                    if response.status_code not in (401, 403):
+                        logger.warning(
+                            "Unexpected Sokosumi bearer validation response: %s %s",
+                            path,
+                            response.status_code,
+                        )
+        except httpx.HTTPError as e:
+            logger.warning("Sokosumi bearer validation failed: %s", e)
+
+        return False
 
     def _unauthorized_response(self, detail: str) -> Response:
         """Return a 401 Unauthorized response with WWW-Authenticate header."""

--- a/server.py
+++ b/server.py
@@ -64,14 +64,15 @@ current_api_key: ContextVar[Optional[str]] = ContextVar('current_api_key', defau
 current_network: ContextVar[Optional[str]] = ContextVar('current_network', default=None)
 current_user: ContextVar[Optional[Dict[str, Any]]] = ContextVar('current_user', default=None)
 
-# Middleware for authentication (API key or OAuth Bearer token)
+# Middleware for authentication (API key, direct Bearer token, or OAuth Bearer JWT)
 class AuthenticationMiddleware(BaseHTTPMiddleware):
     """
     Authentication middleware supporting dual auth:
-    1. API key (query param ?api_key= or header x-api-key)
-    2. OAuth 2.1 Bearer token (Authorization: Bearer <jwt>)
+    1. API key (query param ?api_key= or header x-api-key/token)
+    2. Direct Sokosumi token (Authorization: Bearer <api key or access token>)
+    3. OAuth 2.1 Bearer token (Authorization: Bearer <jwt>)
 
-    Priority: API key takes precedence over Bearer token.
+    Priority: explicit API key takes precedence over Bearer token.
     If neither is provided/valid, returns 401 with WWW-Authenticate header.
     """
 
@@ -102,9 +103,22 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                 response = await call_next(request)
                 return self._cleanup_and_return(response, api_token, network_token, user_token)
 
-            # Try Bearer token authentication
+            # Try Bearer token authentication. JWTs are MCP OAuth tokens issued
+            # by this server; non-JWT bearer values are passed through as direct
+            # Sokosumi API/OAuth tokens for compatibility with clients that only
+            # expose a Bearer token field.
             bearer_token = self._extract_bearer_token(request)
             if bearer_token:
+                if not self._is_probably_jwt(bearer_token):
+                    api_token = current_api_key.set(bearer_token)
+                    api_keys["current"] = bearer_token
+                    logger.info(
+                        "Authenticated via direct Bearer token: %s...",
+                        bearer_token[:8],
+                    )
+                    response = await call_next(request)
+                    return self._cleanup_and_return(response, api_token, network_token, user_token)
+
                 try:
                     user_payload = await validate_access_token(bearer_token)
                     user_token = current_user.set(user_payload)
@@ -143,13 +157,19 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
     def _extract_api_key(self, request: Request) -> Optional[str]:
         """Extract API key from query param or header."""
-        # Check query parameter first
-        api_key = request.query_params.get('api_key')
+        # Check query parameter first. `api_key` is the documented legacy
+        # remote URL form; the aliases accept older/generated variants safely.
+        api_key = (
+            request.query_params.get('api_key')
+            or request.query_params.get('apiKey')
+            or request.query_params.get('token')
+            or request.query_params.get('access_token')
+        )
         if api_key:
             return api_key
 
-        # Check x-api-key header
-        api_key = request.headers.get('x-api-key')
+        # Check API key headers
+        api_key = request.headers.get('x-api-key') or request.headers.get('token')
         if api_key:
             return api_key
 
@@ -161,6 +181,10 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
         if auth_header.lower().startswith('bearer '):
             return auth_header[7:]  # Remove "Bearer " prefix
         return None
+
+    def _is_probably_jwt(self, token: str) -> bool:
+        """Return true when a bearer value has the compact JWT shape."""
+        return token.count(".") == 2
 
     def _unauthorized_response(self, detail: str) -> Response:
         """Return a 401 Unauthorized response with WWW-Authenticate header."""

--- a/server.py
+++ b/server.py
@@ -21,6 +21,7 @@ from starlette.routing import Route
 from contextvars import ContextVar
 
 from oauth import (
+    MCP_SERVER_URL,
     SOKOSUMI_USERINFO_ENDPOINT,
     validate_access_token,
     get_protected_resource_metadata,
@@ -103,13 +104,13 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                 response = await call_next(request)
                 return self._cleanup_and_return(response, api_token, network_token, user_token)
 
-            # Try Bearer token authentication. JWTs are MCP OAuth tokens issued
-            # by this server; non-JWT bearer values are passed through as direct
-            # Sokosumi API/OAuth tokens for compatibility with clients that only
-            # expose a Bearer token field.
+            # Try Bearer token authentication. MCP OAuth tokens are JWTs issued
+            # by this server. Other bearer values, including Sokosumi tokens that
+            # happen to use JWT format, are passed through as direct Sokosumi
+            # API/OAuth tokens for clients that only expose a Bearer token field.
             bearer_token = self._extract_bearer_token(request)
             if bearer_token:
-                if not self._is_probably_jwt(bearer_token):
+                if not self._is_mcp_access_token(bearer_token):
                     api_token = current_api_key.set(bearer_token)
                     api_keys["current"] = bearer_token
                     logger.info(
@@ -182,9 +183,32 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             return auth_header[7:]  # Remove "Bearer " prefix
         return None
 
-    def _is_probably_jwt(self, token: str) -> bool:
-        """Return true when a bearer value has the compact JWT shape."""
-        return token.count(".") == 2
+    def _is_mcp_access_token(self, token: str) -> bool:
+        """Return true only for JWTs issued by this MCP server."""
+        if token.count(".") != 2:
+            return False
+
+        try:
+            payload = jwt.decode(
+                token,
+                options={
+                    "verify_signature": False,
+                    "verify_exp": False,
+                    "verify_iat": False,
+                    "verify_nbf": False,
+                    "verify_aud": False,
+                    "verify_iss": False,
+                },
+            )
+        except jwt.InvalidTokenError:
+            return False
+
+        audience = payload.get("aud")
+        has_expected_audience = (
+            audience == MCP_SERVER_URL
+            or (isinstance(audience, list) and MCP_SERVER_URL in audience)
+        )
+        return payload.get("iss") == MCP_SERVER_URL and has_expected_audience
 
     def _unauthorized_response(self, detail: str) -> Response:
         """Return a 401 Unauthorized response with WWW-Authenticate header."""

--- a/server.py
+++ b/server.py
@@ -603,7 +603,7 @@ async def list_agents() -> Dict[str, Any]:
     """
     api_key = get_current_api_key()
     if not api_key:
-        return {"error": "No API key found. Please connect with ?api_key=xxx in URL"}
+        return auth_error()
 
     base_url = get_base_url()
     url = f"{base_url}/v1/agents"
@@ -646,7 +646,7 @@ async def get_agent_input_schema(agent_id: str) -> Dict[str, Any]:
     """
     api_key = get_current_api_key()
     if not api_key:
-        return {"error": "No API key found. Please connect with ?api_key=xxx in URL"}
+        return auth_error()
 
     base_url = get_base_url()
     url = f"{base_url}/v1/agents/{agent_id}/input-schema"
@@ -722,7 +722,7 @@ async def create_job(
     """
     api_key = get_current_api_key()
     if not api_key:
-        return {"error": "No API key found. Please connect with ?api_key=xxx in URL"}
+        return auth_error()
 
     schema_response = await sokosumi_api_request(
         "GET",
@@ -767,7 +767,7 @@ async def get_job(job_id: str) -> Dict[str, Any]:
     """
     api_key = get_current_api_key()
     if not api_key:
-        return {"error": "No API key found. Please connect with ?api_key=xxx in URL"}
+        return auth_error()
 
     base_url = get_base_url()
     url = f"{base_url}/v1/jobs/{job_id}"
@@ -811,7 +811,7 @@ async def list_agent_jobs(agent_id: str) -> Dict[str, Any]:
     """
     api_key = get_current_api_key()
     if not api_key:
-        return {"error": "No API key found. Please connect with ?api_key=xxx in URL"}
+        return auth_error()
 
     base_url = get_base_url()
     url = f"{base_url}/v1/agents/{agent_id}/jobs"
@@ -857,7 +857,7 @@ async def get_user_profile() -> Dict[str, Any]:
     """
     api_key = get_current_api_key()
     if not api_key:
-        return {"error": "No API key found. Please connect with ?api_key=xxx in URL"}
+        return auth_error()
 
     base_url = get_base_url()
     url = f"{base_url}/v1/users/me"
@@ -1323,7 +1323,7 @@ async def search(query: str) -> Dict[str, Any]:
         return {
             "content": [{
                 "type": "text",
-                "text": json.dumps({"error": "No API key found. Please connect with ?api_key=xxx in URL"})
+                "text": json.dumps(auth_error())
             }]
         }
 
@@ -1420,7 +1420,7 @@ async def fetch(id: str) -> Dict[str, Any]:
         return {
             "content": [{
                 "type": "text",
-                "text": json.dumps({"error": "No API key found. Please connect with ?api_key=xxx in URL"})
+                "text": json.dumps(auth_error())
             }]
         }
 

--- a/skills/agents/SKILL.md
+++ b/skills/agents/SKILL.md
@@ -13,6 +13,7 @@ Workflow:
 1. Verify the connection with `get_user_profile` unless another Sokosumi MCP tool already succeeded in this turn.
 2. For discovery, call `list_agents`, `list_categories`, or `search`.
 3. For a specific agent, call `get_agent` and `get_agent_input_schema`.
-4. To hire an agent, confirm the deliverable and credit cap, ask for missing required schema fields, call `create_job`, then return the job id, agent, status, and monitoring step.
+4. To hire an agent, confirm the deliverable and credit cap, ask for missing required schema fields, call `create_job`, then start `sokosumi:watch` if the job is still running.
+5. Return the job id, agent, status, and tell the user whether it is being watched in the background.
 
 Use coworker tasks instead of direct jobs when the user has a broad outcome that needs coordination.

--- a/skills/market/SKILL.md
+++ b/skills/market/SKILL.md
@@ -15,4 +15,5 @@ Workflow:
 3. Resolve Hannah with `get_coworker(coworker="hannah")`.
 4. Create a READY task with `create_coworker_task(coworker="hannah", description=<brief>, name=<short title>, status="READY")`.
 5. If Hannah is unavailable, search agents with marketing, market research, SEO, audience, or competitor terms and follow the direct agent job workflow.
-6. Return the task or job id and status.
+6. After creating a READY task or direct job, immediately start background monitoring with `sokosumi:watch` using the task or job id. Do not wait for the work to finish.
+7. Return the task or job id, status, and tell the user it is being watched in the background.

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -14,6 +14,7 @@ Workflow:
 2. Verify the connection with `get_user_profile`. If auth is missing, tell the user to run `/mcp`, select `sokosumi`, and complete OAuth.
 3. For broad marketing, customer, competitor, or business research, use Hannah: `create_coworker_task(coworker="hannah", description=<brief>, name=<short title>, status="READY")`.
 4. For a direct research-agent job, use `search(query="research " + <brief>)` or `list_agents`, choose a relevant agent, call `get_agent_input_schema`, ask for missing required fields, then call `create_job`.
-5. Return the task id or job id and the expected follow-up.
+5. After creating a READY task or direct job, immediately start background monitoring with `sokosumi:watch` using the task or job id. Do not wait for the work to finish.
+6. Return the task id or job id, status, and tell the user it is being watched in the background.
 
 Do not fabricate sources or capabilities. Use the marketplace and job data returned by Sokosumi.

--- a/skills/sokosumi/SKILL.md
+++ b/skills/sokosumi/SKILL.md
@@ -62,9 +62,9 @@ Before hiring an agent:
 4. Build `input_data` from the schema. Do not guess missing required fields.
 5. Use `create_job` with a clear job name and `max_accepted_credits`.
 6. Keep the returned job id in context.
-7. Use `get_job`, `list_job_events`, `list_job_files`, and `list_job_links` to monitor and report status.
+7. If the job is still running, start background monitoring with the `sokosumi:watch` skill so the job is not forgotten while it runs. You can still check manually any time with `get_job`, `list_job_events`, `list_job_files`, and `list_job_links`.
 8. If `get_job_input_request` shows a pending request, ask the user for the missing values and call `provide_job_input`.
 
-Jobs usually do not complete immediately. If a job is still running, say so clearly and include the job id so the user can ask for another status check later.
+Jobs usually do not complete immediately. If a job is still running, arm the watcher and include the job id in the response.
 
 Default to mainnet. Use preprod only when the user explicitly asks for testing or provides a preprod MCP URL/API key.

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -14,4 +14,4 @@ Workflow:
 2. If the request includes a task id, call `get_task`, `list_task_events`, and `list_task_jobs`.
 3. If no task id is present, call `list_tasks`, filtering by coworker or status when the user mentions one.
 4. Summarize status, latest activity, linked jobs, and the next action. Keep task ids in the response.
-5. If a task is still running and the user wants to be notified when it finishes, start background monitoring with the `sokosumi:watch` skill.
+5. If a task is still running, start background monitoring with the `sokosumi:watch` skill unless it is already being watched.


### PR DESCRIPTION
## Summary
- Update README setup/troubleshooting to point Claude at the hosted OAuth MCP endpoint
- Keep legacy API-key URL support and accept direct bearer/header token forms for compatibility

## Verification
- python3 -m py_compile server.py oauth.py